### PR TITLE
minor-mitigate

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ npm install authboot --save
 
 The `users` object we give contains assumptions if you are not passing in your
 own `lookup` function. Those assumptions is that that each `key` must be the
-username for your authorized users while the value must be a [`bcrypt`][bcrypt]
-[hash](https://github.com/kelektiv/node.bcrypt.js#to-hash-a-password) of the password. This ensures we are following security best practices even
+username for your authorized users while the value must be a [`hexidecimal`][hexidecimal] encoding of the [`sha256`][sha256] hash of the password. This ensures we are following security best practices even
 when this information is loaded in memory from an encrypted config.
 
 ### `lookup({ name, password }, callback)`
 
 Function to override the default behavior of using the `users` object as
-a direct comparison map for who is authorized and using [`bcrypt`][bcrypt] to
+a direct comparison map for who is authorized and using the provided algorithm to
 compare the given password with the `hash` we have stored as part of the `users`
 object.
 
@@ -44,6 +43,10 @@ Indicating whether we will send a challenge response for browser based requests.
 
 The realm given for the service for browser storage of basic auth.
 
+### `algorithm` String
+
+The algorithm given to `crypto` when creating a `hash`.
+
 ## usage
 
 ### Example #1
@@ -53,7 +56,7 @@ The realm given for the service for browser storage of basic auth.
 module.exports = function (app, opts, callback) {
   app.preboot(require('authboot')({
     users: {
-      name: 'bcryptHashOfPassword'
+      name: 'hexOfSHA256HashOfPassword'
     },
     // send challenge request for browser auth
     challenge: true,
@@ -124,4 +127,5 @@ npm test
 ```
 
 [slay]: https://github.com/godaddy/slay
-[bcrypt]: https://github.com/kelektiv/node.bcrypt.js
+[hexidecimal]: https://en.wikipedia.org/wiki/Hexadecimal#Transfer_encoding
+[sha256]: https://en.wikipedia.org/wiki/Secure_Hash_Algorithms#Comparison_of_SHA_functions

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "author": "GoDaddy Operating Company LLC",
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^1.0.3",
     "diagnostics": "^1.1.0",
     "express-basic-auth-safe": "^1.1.4"
   },

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 const assume = require('assume');
-const bcrypt = require('bcrypt');
+const crypto = require('crypto');
 const nconf = require('nconf');
 const authboot = require('./');
 
@@ -60,21 +60,121 @@ describe('authboot.test', function () {
     });
   });
 
+  it('app.authboot.lookup by default should correctly fail on unknown user', function (done) {
+    authboot({ users: { what: '00'  }})(app, {}, (err) => {
+      assume(err).is.falsey();
+      assume(app.authboot.middleware).is.a('function');
+      assume(app.authboot.lookup).is.a('function');
+
+      app.authboot.lookup({ name: 'who', password: '00' }, (err, valid) => {
+        assume(err).is.falsey();
+        assume(valid).is.falsey();
+        done();
+      });
+    });
+  });
+
   it('app.authboot.lookup by default should correctly validate from user object', function (done) {
     const password = 'huh';
-    bcrypt.hash(password, 10, (err, hash) => {
+    const hash = crypto.createHash('sha256');
+    hash.update(password);
+    const digest = hash.digest('hex');
+    authboot({ users: { what: digest  }})(app, {}, (err) => {
       assume(err).is.falsey();
-      authboot({ users: { what: hash  }})(app, {}, (err) => {
-        assume(err).is.falsey();
-        assume(app.authboot.middleware).is.a('function');
-        assume(app.authboot.lookup).is.a('function');
+      assume(app.authboot.middleware).is.a('function');
+      assume(app.authboot.lookup).is.a('function');
 
-        app.authboot.lookup({ name: 'what', password: 'huh' }, (err, valid) => {
-          assume(err).is.falsey();
-          assume(valid).is.truthy();
-          done();
-        });
+      app.authboot.lookup({ name: 'what', password: 'huh' }, (err, valid) => {
+        assume(err).is.falsey();
+        assume(valid).is.truthy();
+        done();
       });
+    });
+  });
+
+  it('app.authboot.lookup by default should coalesce concurrent lookups', function (done) {
+    const password = 'huh';
+    const hash = crypto.createHash('sha256');
+    hash.update(password);
+    const digest = hash.digest('hex');
+    authboot({ users: { what: digest  }})(app, {}, (err) => {
+      assume(err).is.falsey();
+      assume(app.authboot.middleware).is.a('function');
+      assume(app.authboot.lookup).is.a('function');
+
+      const responses = Array.from({ length: 10 }, () => {
+        let f, r;
+        const p = new Promise((_f, _r) => {
+          f = _f;
+          r = _r;
+        });
+        setTimeout(() => {
+          app.authboot.lookup({ name: 'what', password: 'huh' }, (err, valid) => {
+            try {
+              assume(err).is.falsey();
+              assume(valid).is.truthy();
+              f();
+            } catch (e) {
+              r(e);
+            }
+          });
+        }, 0);
+        return p;
+      });
+      Promise.all(responses).then(
+        () => done(),
+        (e) => done(e)
+      );
+    });
+  });
+
+  it('app.authboot.lookup by default should fail on brute force heuristic', function (done) {
+    // default max concurrents is 4
+    const password = '5';
+    const hash = crypto.createHash('sha256');
+    hash.update(password);
+    const digest = hash.digest('hex');
+    authboot({ users: { what: digest  }})(app, {}, (err) => {
+      assume(err).is.falsey();
+      assume(app.authboot.middleware).is.a('function');
+      assume(app.authboot.lookup).is.a('function');
+
+      const responses = Array.from({ length: 6 }, (_, i) => {
+        let f, r;
+        const p = new Promise((_f, _r) => {
+          f = _f;
+          r = _r;
+        });
+        setTimeout(() => {
+          app.authboot.lookup({ name: 'what', password: `${i}` }, (err, valid) => {
+            try {
+              assume(err).is.falsey();
+              assume(valid).is.falsey();
+              f();
+            } catch (e) {
+              r(e);
+            }
+          });
+        }, 0);
+        return p;
+      });
+      responses.push(new Promise(async (f, r) => {
+        await Promise.all(responses);
+        app.authboot.lookup({ name: 'what', password: '5' }, (err, valid) => {
+          try {
+            assume(err).is.falsey();
+            assume(valid).is.truthy();
+            f();
+          } catch (e) {
+            r(e);
+          }
+        });
+      }));
+
+      Promise.all(responses).then(
+        () => done(),
+        (e) => done(e)
+      );
     });
   });
 });


### PR DESCRIPTION
does some naive mitigations for DDoS targets mitigation via:

* coalescing - batches similar name/guess pairs for a single loop to survive bursts and event loop bloat

care is taken not to directly associate the trie used for this with if an operation is successful

* brute force heuristic - only allows `n` number of concurrent name/guess pairs to occur for a single `name` within a loop. this could have been done with an LRU and max age, but i chose to reuse the coalescing trie

* moved to `crypto` for default implementation - `bcrypt` time consumption is significant

leaving IP DDoS for whatever gateway feeds into the server.